### PR TITLE
Fix info version regex

### DIFF
--- a/src/schema/schemas/microservice.ts
+++ b/src/schema/schemas/microservice.ts
@@ -8,7 +8,7 @@ module.exports = {
       properties: {
         version: {
           type: 'string',
-          pattern: '[0-9]*\\.[0-9]*\\.[0-9]*',
+          pattern: '[0-9]*\.[0-9]*\.[0-9]*',
         },
         title: {
           type: 'string',


### PR DESCRIPTION
The current regex will match versions of the form '0\.0\.1'. This commit
removes the extra '\' characters to match of the form '0.0.1'.

You can test this out at https://regexr.com/

Try `[0-9]*\.[0-9]*\.[0-9]*` and `[0-9]*\\.[0-9]*\\.[0-9]*` with `0.0.1` and `0\.0\.1`